### PR TITLE
Add ax-extract-workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@
   **什么时候用：** 自己写新 skill 时不想从零搭基础结构，或想跨 Claude Code / Codex 平台时。
   **作者：** [@huangwb8](https://github.com/huangwb8)　**标签：** `脚手架` `开发流水线` `Codex 兼容`
 
+- **[ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow)** — 基于本地 ax 会话、提交记录、skill 使用和 sub-agent 活动，还原 PR、功能或报告的交付过程。
+  **什么时候用：** 需要复盘一次交付、提炼可复用流程，或梳理 agent 协作过程时。
+  **作者：** [@Necmttn](https://github.com/Necmttn)　**标签：** `工作流复盘` `agent协作` `本地记录` `Claude Code`
+
 - **[claude-skills-suite](https://github.com/joneqian/claude-skills-suite)** — 全栈 skill 套件：14 个 Agents + 16 个 Commands + 40 个 Skills，含 D3 可视化、PostgreSQL/MySQL、微信小程序等国内技术栈。
   **什么时候用：** 想要一个开箱即用的大套件，尤其是涉及国内技术栈（微信小程序、TDesign）时。
   **作者：** [@joneqian](https://github.com/joneqian)　**标签：** `合集` `全栈` `微信小程序` `数据库`


### PR DESCRIPTION
## Skill 信息

- **名称：** ax-extract-workflow
- **原仓库链接：** https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow
- **作者：** @Necmttn
- **分类：** 开发辅助
- **标签：** 工作流复盘、agent协作、本地记录、Claude Code

## 一句话介绍

基于本地 ax 记录还原交付过程。

## 什么时候用

需要复盘一次 PR、功能或报告的交付过程，提炼可复用流程，或梳理一次 agent 协作过程时。

## 我已确认

- [x] 这个 skill 真实可用，我自己跑通过
- [x] 原仓库包含 `SKILL.md` 或等价文档
- [x] 这个 skill 不是简单的 prompt 包装，有清晰的功能边界
- [x] 如果是付费 skill，我已在介绍中标注 `商业` 标签并说明定价
- [x] 我已阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 并按格式编辑了 README.md

## 自荐 or 推荐？

- [x] 这是我自己的 skill（自荐）
- [ ] 这是别人的 skill，我已告知原作者（推荐）
- [ ] 这是别人的 skill，我没法联系到原作者（推荐）

## 其他备注

只改 README.md。验证：`git diff --check -- README.md` 通过；新增 skill 链接返回 HTTP 200。非付费 skill，商业标签不适用。

---

_Generated with [ax](https://github.com/Necmttn/ax)._
