### PR TITLE
feat: add NotFair — SEO, Google Ads & Meta Ads skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@
   **什么时候用：** 批量做短视频字幕、信息流摘要时——中文短视频平台全覆盖。
   **作者：** [@imlewc](https://github.com/imlewc)　**标签：** `视频字幕` `Whisper` `抖音` `B站`
 
+- **[NotFair](https://github.com/nowork-studio/NotFair)** — 面向营销人员的开源 Claude Code skill 套件，含 [SEO](https://github.com/nowork-studio/NotFair/tree/main/seo)（关键词研究、元标签、Schema、内容写作、GEO）、[Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads)（审计、搜索词清理、竞价管理）、[Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads)（ROAS 分析、素材疲劳检测、受众重叠），通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics (GA4) MCP 接入真实数据。（MIT 协议，~2.9k ★）
+  **什么时候用：** 需要 Claude Code 直连广告后台做 SEO 诊断、Google Ads 浪费支出排查或 Meta 广告效果分析时。
+  **作者：** [@nowork-studio](https://github.com/nowork-studio)　**标签：** `SEO` `Google Ads` `Meta Ads` `MCP` `营销`
+
 ### 数据处理
 
 > CSV/Excel 处理、SQL 查询、数据清洗、可视化、报表生成等。


### PR DESCRIPTION
感谢维护这个列表！

想推荐一个最近发现的开源 Claude Code skill 套件 —— **[NotFair](https://github.com/nowork-studio/NotFair)**（MIT 协议，~2.9k ★），专门面向营销场景：

- **[seo/](https://github.com/nowork-studio/NotFair/tree/main/seo)**：网站诊断、关键词研究、元标签优化、Schema Markup、GEO 优化、内容写作
- **[google-ads/](https://github.com/nowork-studio/NotFair/tree/main/google-ads)**：账户审计、浪费支出检测、搜索词清理、竞价管理
- **[meta-ads/](https://github.com/nowork-studio/NotFair/tree/main/meta-ads)**：ROAS 分析、素材疲劳检测、受众重叠

它通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics (GA4) MCP 直接接入真实广告数据，而不只是生成建议文案——这是它区别于普通 prompt 模板的地方。

放在了"文档与写作"分类下，因为 SEO 和内容写作是核心能力之一。如果觉得另开"营销"分类更合适，或者描述需要调整，完全可以改，欢迎指出。