### PR TITLE
添加 tree-ring-memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@
   **什么时候用：** 自己写新 skill 时不想从零搭基础结构，或想跨 Claude Code / Codex 平台时。
   **作者：** [@huangwb8](https://github.com/huangwb8)　**标签：** `脚手架` `开发流水线` `Codex 兼容`
 
+- **[tree-ring-memory](https://github.com/TerminallyLazy/tree-ring-memory-skill)** — 本地优先的 agent 记忆生命周期 skill，指导 Claude 进行项目记忆召回、证据记录、审计、遗忘与合并。
+  **什么时候用：** 做长期项目、代码代理交接、复盘已验证决策或踩坑，并且需要可删除、可审计的本地记忆时。
+  **作者：** [@TerminallyLazy](https://github.com/TerminallyLazy)　**标签：** `记忆` `本地优先` `审计` `遗忘`
+
 - **[claude-skills-suite](https://github.com/joneqian/claude-skills-suite)** — 全栈 skill 套件：14 个 Agents + 16 个 Commands + 40 个 Skills，含 D3 可视化、PostgreSQL/MySQL、微信小程序等国内技术栈。
   **什么时候用：** 想要一个开箱即用的大套件，尤其是涉及国内技术栈（微信小程序、TDesign）时。
   **作者：** [@joneqian](https://github.com/joneqian)　**标签：** `合集` `全栈` `微信小程序` `数据库`


### PR DESCRIPTION
## Skill 信息

- **名称：** tree-ring-memory
- **原仓库链接：** https://github.com/TerminallyLazy/tree-ring-memory-skill
- **作者：** @TerminallyLazy
- **分类：** 开发辅助
- **标签：** `记忆` `本地优先` `审计` `遗忘`

## 一句话介绍

本地优先的 agent 记忆生命周期。

## 什么时候用

做长期项目、代码代理交接、复盘已验证决策或踩坑，并且需要可删除、可审计的本地记忆时。

## 我已确认

- [x] 这个 skill 真实可用，我自己跑通过
- [x] 原仓库包含 `SKILL.md` 或等价文档
- [x] 这个 skill 不是简单的 prompt 包装，有清晰的功能边界
- [x] 如果是付费 skill，我已在介绍中标注 `商业` 标签并说明定价
- [x] 我已阅读 [CONTRIBUTING.md](../CONTRIBUTING.md) 并按格式编辑了 README.md

## 自荐 or 推荐？

- [x] 这是我自己的 skill（自荐）
- [ ] 这是别人的 skill，我已告知原作者（推荐）
- [ ] 这是别人的 skill，我没法联系到原作者（推荐）

## 其他备注

本地验证：

- 已确认没有现有 Tree Ring Memory / tree-ring / TerminallyLazy PR 或 issue。
- 已确认 https://github.com/TerminallyLazy/tree-ring-memory-skill 返回 HTTP 200。
- 已运行 `git diff --check`。
- 已用隔离目录 `/tmp/trm-shishirui-smoke` 跑通 `tree-ring init`、`tree-ring remember`、`tree-ring recall`、`tree-ring forget`。
- 这是免费开源项目，不是商业付费 skill。