### PR TITLE
添加 maoxuan-product-agent 中文产品决策 Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@
 
 > 代码 review、调试、重构、测试生成、版本管理等开发流程中的辅助技能。
 
+- **[maoxuan-product-agent](https://github.com/atdy/maoxuan-product-agent)** — 从《矛盾论》《实践论》蒸馏的中文产品决策 Agent。
+  **什么时候用：** 做需求优先级、Roadmap、增长与留存诊断、指标异常、项目延期或跨团队协作时，快速判断真正卡点和下一步。
+  **作者：** [@atdy](https://github.com/atdy)　**标签：** `产品管理` `需求决策` `增长` `中文输出` `Codex兼容`
+
 - **[yunshu_skillshub](https://github.com/yunshu0909/yunshu_skillshub)** — 云舒整理的 Claude Code skill 集合，覆盖周报、PRD、UI 设计、需求分析等开发与产品工作流。
   **什么时候用：** 需要从 git commit / 会议记录自动生成周报，或做产品需求文档与 UI 风格迭代时。
   **作者：** [@yunshu0909](https://github.com/yunshu0909)　**标签：** `合集` `周报` `PRD` `产品管理`


### PR DESCRIPTION
## Skill 信息

- **名称：** maoxuan-product-agent
- **原仓库链接：** https://github.com/atdy/maoxuan-product-agent
- **作者：** @atdy
- **分类：** 开发辅助
- **标签：** 产品管理、需求决策、增长、中文输出、Codex 兼容

## 一句话介绍

从《矛盾论》《实践论》蒸馏的中文产品决策 Agent。

## 什么时候用

做需求优先级、Roadmap、增长与留存诊断、指标异常、项目延期或跨团队协作时，快速判断真正卡点、优先行动和暂时不要做什么。

## 我已确认

- [x] 这个 skill 真实可用，我自己跑通过
- [x] 原仓库包含 `SKILL.md` 和完整使用文档
- [x] 这个 skill 不是简单的 prompt 包装，有清晰的功能边界
- [x] 这是免费开源 Skill，不涉及付费
- [x] 我已阅读 `CONTRIBUTING.md` 并按格式编辑了 `README.md`

## 自荐 or 推荐？

- [x] 这是我自己的 skill（自荐）
- [ ] 这是别人的 skill，我已告知原作者（推荐）
- [ ] 这是别人的 skill，我没法联系到原作者（推荐）

## 其他备注

- 36 个真实产品场景回归测试全部通过
- 另有 4 个全新 Claude Code 前向测试
- 支持 Claude Code、Codex、Cursor 等 Agent Skills 兼容工具
- 默认只输出现代产品判断和行动建议，不讲理论、不引用原文
- MIT 开源，无外部 API 或凭据依赖
